### PR TITLE
Refactor API #54

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,4 +66,3 @@ jspm_packages
 .idea
 config.js
 build/
-server/config

--- a/server/config/serverConfig.js
+++ b/server/config/serverConfig.js
@@ -1,0 +1,7 @@
+const config =  {
+  port: process.env.PORT || 3000,
+  URL_ROOT: 'https://api.twitch.tv/kraken',
+  API_KEY: 'ADD_YOUR_API_KEY_HERE',
+};
+
+export default config;

--- a/src/js/actions/featureStreamAction.js
+++ b/src/js/actions/featureStreamAction.js
@@ -1,12 +1,12 @@
 import request from "superagent";
 import * as types from "../constants/";
-import API_KEY from '../../../server/config/api_key';
+import config from '../../../server/config/serverConfig';
 
 export const reqFeatureStreams = featured => {
 
   const promise = new Promise((resolve, reject) => {
     request
-      .get(`https://api.twitch.tv/kraken/streams/featured?limit=48&offset=0&client_id=${API_KEY}`)
+      .get(`${config.ROOT_URL}/streams/featured?limit=48&offset=0&client_id=${config.API_KEY}`)
       .end((err, res) => {
         if (err) {
           reject(err);

--- a/src/js/actions/gameActions.js
+++ b/src/js/actions/gameActions.js
@@ -6,7 +6,7 @@ export const reqAllGames = games => {
 
   const promise = new Promise((resolve, reject) => {
     request
-      .get(`https://api.twitch.tv/kraken/games/top?limit=24&offset=0&client_id=${API_KEY}`)
+      .get(`${config.ROOT_URL}/${config.API_KEY}`)
       .end((err, res) => {
         if (err) {
           reject(err);

--- a/src/js/actions/streamActions.js
+++ b/src/js/actions/streamActions.js
@@ -1,12 +1,12 @@
 import request from "superagent";
 import * as types from "../constants/";
-import API_KEY from '../../../server/config/api_key';
+import config from '../../../server/config/serverConfig';
 
 export const reqStreams = (game) => {
 
   const promise = new Promise((resolve, reject) => {
     request
-      .get(`https://api.twitch.tv/kraken/search/streams?limit=100&offset=0&q=${game}&client_id=${API_KEY}`)
+      .get(`${config.ROOT_URL}/${game}&client_id=${config.API_KEY}`)
       .end((err, res) => {
         if (err) {
           reject(err);

--- a/src/js/actions/videoAction.js
+++ b/src/js/actions/videoAction.js
@@ -1,12 +1,12 @@
 import request from "superagent";
 import * as types from "../constants/";
-import API_KEY from '../../../server/config/api_key';
+import config from '../../../server/config/serverConfig';
 
 export const reqVideos = name => {
 
   const promise = new Promise((resolve, reject) => {
     request
-      .get(`https://api.twitch.tv/kraken/channels/${name}/videos&client_id=${API_KEY}`)
+      .get(`${config.ROOT_URL}/${name}/videos&client_id=${config.API_KEY}`)
       .end((err, res) => {
         if (err) {
           reject(err);


### PR DESCRIPTION
@EQuimper 

I have refactored for issue #54 so `ROOT_URL` and `API_KEY` can be changed in one location when in future if either one changes. 

I removed hiding config so others can use similar setup and add their own `API_KEY`

I didn't update server.js with port from serverConfig.js, thought we could do this in another PR in future

Please review brother and look forward to your thoughts and merge :)
